### PR TITLE
Add stats import to Tb_Gates

### DIFF
--- a/R/OperativeTemperatureFunctions.R
+++ b/R/OperativeTemperatureFunctions.R
@@ -87,6 +87,7 @@ Qnet_Gates=function(Qabs, Qemit, Qconv, Qcond, Qmet, Qevap){
 #' @return operative environmental temperature (K)
 #' @keywords operative environmental temperature
 #' @family biophysical models
+#' @import stats
 #' @export
 #' @examples 
 #' \dontrun{


### PR DESCRIPTION
Tb_Gates uses the uniroot function from the stats package. We need to import it.

Part of this error message: 

> Tb_Gates: no visible global function definition for ‘uniroot’
> soil_temperature_equation: no visible global function definition for
>   ‘integrate’
> soil_temperature_function: no visible global function definition for
>   ‘uniroot’
> surface_roughness: no visible global function definition for ‘lm’
> Undefined global functions or variables:
>   integrate lm unroot
> Consider adding
>   importFrom("stats", "integrate", "lm", "uniroot")