### PR TITLE
Add stats import to functions

### DIFF
--- a/R/TsoilFunctions.R
+++ b/R/TsoilFunctions.R
@@ -94,6 +94,7 @@ soil_temperature_integrand<-function(x, L, z0){
 #' @param z0 is surface roughness in m
 #' @param T_inst instantaneous air temperature in K
 #' @param T_s initial soil suface temperature in °C 
+#' @import stats
 #' @return soil temperature function
 #' @keywords soil temperature
 #' @family soil temperature functions
@@ -136,6 +137,7 @@ soil_temperature_equation<- function(L, rho_a, c_a, k, V_inst, z_r, z0, T_inst, 
 #' @return soil temperature function
 #' @keywords soil temperature
 #' @family soil temperature functions
+#' @import stats
 #' @export
 #' @author Joseph Grigg
 #' @examples


### PR DESCRIPTION
soil_temperature_function and soil_temperature_equation both need the stats library in order to run `integrate` and `uniroot`

Part of the following warning: 

> Tb_Gates: no visible global function definition for ‘uniroot’
> soil_temperature_equation: no visible global function definition for
>   ‘integrate’
> soil_temperature_function: no visible global function definition for
>   ‘uniroot’
> surface_roughness: no visible global function definition for ‘lm’
> Undefined global functions or variables:
>   integrate lm unroot
> Consider adding
>   importFrom("stats", "integrate", "lm", "uniroot")
> to your NAMESPACE file.