### PR TITLE
add stats import to surface_roughness function

### DIFF
--- a/R/TempWindProfileFunctions.R
+++ b/R/TempWindProfileFunctions.R
@@ -13,6 +13,7 @@
 #' @return surface roughness (m)
 #' @keywords wind profile
 #' @family microclimate functions
+#' @import stats
 #' @export
 #' @examples
 #' \dontrun{


### PR DESCRIPTION
'surface_roughness' uses the lm function from the stats package. I believe we need to import it.



