### PR TITLE
Unnecessary keyword removing

### DIFF
--- a/R/biophysmodel_Colias.R
+++ b/R/biophysmodel_Colias.R
@@ -15,7 +15,6 @@
 #' @param r_g is substrate solar reflectivity (proportion), see Kingsolver (1983)
 #' @param shade is whether body temperature should be calculate in sun (FALSE) or shade (TRUE)
 #' @return predicted body (operative environmental) temperature (°C)
-#' @keywords body temperature biophysical model
 #' @family biophysical models
 #' @export
 #' @examples

--- a/R/biophysmodel_Grasshopper.R
+++ b/R/biophysmodel_Grasshopper.R
@@ -16,7 +16,6 @@
 #' @param abs is absorptivity of grasshopper to solar radiation (proportion), See Anderson et al. (1979).
 #' @param r_g is substrate solar reflectivity (proportion), see Kingsolver (1983)
 #' @return predicted body (operative environmental) temperature (°C)
-#' @keywords body temperature biophysical model
 #' @family biophysical models
 #' @export
 #' @examples

--- a/R/biophysmodel_Limpet.R
+++ b/R/biophysmodel_Limpet.R
@@ -11,7 +11,6 @@
 #' @param c fraction of the sky covered by cloud 
 #' @param position the direction of the limpet that is facing upwind. Options are "anterior", "posterior" and "broadside".
 #' @return predicted body temperature (°C)
-#' @keywords body temperature biophysical model
 #' @family biophysical models
 #' @export
 #' @examples

--- a/R/biophysmodel_LizardFei.R
+++ b/R/biophysmodel_LizardFei.R
@@ -13,7 +13,6 @@
 #' @param Acondfact is the proportion of the lizard projected area that is in contact with the ground, Acondfact=0.1 for standing and Acondfact=0.4 for lying on ground
 #' @param Agradfact is the proportion of the lizard projected area exposed to radiation from the ground, Agradfact=0.3 for standing and Agradfact=0.0 for lying on ground
 #' @return Body temperature of a lizard in K
-#' @keywords Operative Temperature Fei
 #' @family biophysical models
 #' @author Ofir Levy
 #' @export 

--- a/R/biophysmodel_Mussel.R
+++ b/R/biophysmodel_Mussel.R
@@ -16,7 +16,6 @@
 #' @param group options are "aggregated": mussels living in beds, "solitary": mussels individuals, anterior or posterior end facing upwind, 
 #'              and "solitary_valve": solitary individuals, valve facing upwind
 #' @return predicted body temperature (°C)
-#' @keywords body temperature biophysical model
 #' @family biophysical models
 #' @export
 #' @examples

--- a/R/biophysmodel_MusselBed.R
+++ b/R/biophysmodel_MusselBed.R
@@ -11,7 +11,6 @@
 #' @param evap Are mussels gaping to evaporatively cool? TRUE of FALSE (default), If TRUE, assumes constant mass loss rate of 5 percent of initial body mass per hour 
 #' @param cl fraction of the sky covered by cloud, optional
 #' @return predicted body temperature (°C)
-#' @keywords body temperature biophysical model
 #' @family biophysical models
 #' @export
 #' @examples

--- a/R/biophysmodel_Sceloporus.R
+++ b/R/biophysmodel_Sceloporus.R
@@ -24,7 +24,6 @@
 #' @param F_a is the view factor between the surface of the lizard and atmospheric radiation
 #' @param F_g is the view factor between the surface of the lizard and ground thermal radation
 #' @return T_e Operative temperature (°C)
-#' @keywords body temperature biophysical model
 #' @family biophysical models
 #' @export 
 #' @examples

--- a/R/biophysmodel_Snail.R
+++ b/R/biophysmodel_Snail.R
@@ -11,7 +11,6 @@
 #' @param WL water loss rate (kg/s), 5 percent loss of body mass over one hour is a reasonable maximum level (Helmuth 1999)
 #' @param WSH wind sensor height (m)
 #' @return predicted body temperature (°C)
-#' @keywords body temperature biophysical model
 #' @family biophysical models
 #' @export
 #' @author Brian Helmuth Lab

--- a/R/biophysmodel_limpetBH.R
+++ b/R/biophysmodel_limpetBH.R
@@ -11,7 +11,6 @@
 #' @param s_slope solar elevation angle (degree), the altitude of the Sun, which is the angle between the horizon and the sun
 #' @param c fraction of the sky covered by cloud 
 #' @return predicted body temperature (°C)
-#' @keywords body temperature biophysical model
 #' @family biophysical models
 #' @export
 #' @author Brian Helmuth lab 


### PR DESCRIPTION
Keywords are evidently mainly used for letting R know which functions are user-oriented vs internal and not very useful generally for tagging similar functions. 